### PR TITLE
Release 0.2.0-59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.2.0-59](https://github.com/zyndex-drive/server/compare/v0.2.0-58...v0.2.0-59) (2022-06-23)
+
+
+### Features 🔥
+
+* **plugins/auth/helpers:** write a asyncwhileloop function for use in auth helper functions ([332518b](https://github.com/zyndex-drive/server/commit/332518b5afcc6a0a2ecd10bdbef1954bd9264624))
+* **plugins/errors:** add a new not allowed error response class ([b6f415c](https://github.com/zyndex-drive/server/commit/b6f415cf17a03024c469fcdeeab8ec8d59c2272c))
+
+
+### Others 🔧
+
+* **types/express:** add express header types for x-session-id and x-session-token ([71c88c0](https://github.com/zyndex-drive/server/commit/71c88c008f15b9aa2eb70e6492181f447be81b49))
+
+
+### Code Refactoring 🖌
+
+* **plugins/server/middleware:** update session checker function to use the new session headers ([e995941](https://github.com/zyndex-drive/server/commit/e995941e35166606121d967cd01403529d977de2))
+
+
+### Bug Fixes 🛠
+
+* **plugins/auth/helper:** fix mathjs module import line, add owner to heirarchy ([92f0490](https://github.com/zyndex-drive/server/commit/92f0490968481239b469e863763e5234453f111e))
+* **plugins/auth/helpers:** remove existing while loop and use asyncwhileloop function ([ef3c1ad](https://github.com/zyndex-drive/server/commit/ef3c1adef73b06420951cafbfc5608dd5cf48f8f))
+* **plugins/auth/policy:** restrict editing 'code' prop in policy document ([386af4c](https://github.com/zyndex-drive/server/commit/386af4c49821cdd608baf26fed632ac4c93339c0))
+* **plugins/cors:** allow x-session-id & x-session-token to be allowed in cors requests ([f3b6ee7](https://github.com/zyndex-drive/server/commit/f3b6ee72372ce05138c1c76182eb7f017a2c6608))
+* **plugins/session-manager:** use updated error classes for more proper responses to user ([cb5d02f](https://github.com/zyndex-drive/server/commit/cb5d02f5e9934bf1e674c5a77892fad0745494c2))
+
 ## [0.2.0-58](https://github.com/zyndex-drive/server/compare/v0.2.0-57...v0.2.0-58) (2022-06-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zyndex-server",
-  "version": "0.2.0-58",
+  "version": "0.2.0-59",
   "description": "Backend Server for Handling Zyndex Frontend Requests",
   "main": "app.js",
   "scripts": {

--- a/src/plugins/auth/helpers/heirarchy.ts
+++ b/src/plugins/auth/helpers/heirarchy.ts
@@ -1,6 +1,6 @@
 /* eslint-disable quote-props */
 import dotProp from 'dot-prop';
-import mathjs from 'mathjs';
+import { max as maximum } from 'mathjs';
 
 import type { IRoleDoc, IRoleLeanDoc } from '@models/types';
 
@@ -9,6 +9,7 @@ export const heirarchy = {
   'Content Manager': 1,
   Moderator: 2,
   Manager: 3,
+  Owner: 4,
 };
 
 export const getHeirarchy = (roleDoc: IRoleDoc): number | undefined =>
@@ -30,7 +31,7 @@ export const getHighestHeirarchy = async (
   );
   await Promise.all(promises);
   const roleNumbers = heirarchies.map((heirarchy) => heirarchy.heirarchy);
-  const highest: number = mathjs.max(roleNumbers);
+  const highest: number = maximum(roleNumbers);
   const [highestRoleDoc] = heirarchies.filter(
     (heirarchy) => heirarchy.heirarchy === highest,
   );

--- a/src/plugins/auth/helpers/policy-checker.ts
+++ b/src/plugins/auth/helpers/policy-checker.ts
@@ -67,6 +67,36 @@ interface IDeeperRoles {
   allowedPolicies: ID<IPolicyDoc>[];
 }
 
+interface asyncWhileLoopResult<T> {
+  nextStartValue: string;
+  finalResult: T;
+}
+
+const runAsyncWhileLoop = async <T, U>(
+  start: string,
+  stop: string,
+  otherHelpers: U,
+  func: (start: string, helpers: U) => Promise<asyncWhileLoopResult<T>>,
+): Promise<T> => {
+  let startValue = start;
+  let result: T | undefined = undefined;
+  while (startValue !== stop) {
+    const { nextStartValue, finalResult } = await func(
+      startValue,
+      otherHelpers,
+    );
+    startValue = nextStartValue;
+    result = finalResult;
+    if (startValue === stop) {
+      return result;
+    }
+  }
+  if (result !== undefined) {
+    return result;
+  } else {
+    throw new Error('Nice');
+  }
+};
 export const getDeeperRoles = async (
   adminRole: string,
   otherPolicies?: ID<IPolicyDoc>[],

--- a/src/plugins/auth/helpers/policy-checker.ts
+++ b/src/plugins/auth/helpers/policy-checker.ts
@@ -97,41 +97,54 @@ const runAsyncWhileLoop = async <T, U>(
     throw new Error('Nice');
   }
 };
+
+interface IGetDeeperRoleHelpers {
+  roleId: string;
+  userPolicies: ID<IPolicyDoc>[];
+}
+
 export const getDeeperRoles = async (
   adminRole: string,
   otherPolicies?: ID<IPolicyDoc>[],
 ): Promise<IDeeperRoles> => {
   let userType = '';
-  let roleId = adminRole;
-  let userPolicies: ID<IPolicyDoc>[] = otherPolicies ? otherPolicies : [];
-  const deeperRoles = await new Promise<IDeeperRoles>((resolve, reject) => {
-    while (userType !== 'main') {
-      Roles.findById(roleId)
-        .lean()
-        .exec()
-        .then((roleDoc) => {
-          if (roleDoc) {
-            userType = roleDoc.type;
-            userPolicies = [...roleDoc.allowed_policies, ...userPolicies];
-            if (roleDoc.delgates_from) {
-              roleId = String(roleDoc.delgates_from);
-            }
-            resolve({
-              roleDoc,
-              allowedPolicies: userPolicies,
-            });
-          } else {
-            userType = 'main';
-            reject(new Error("Cannot Find User's Role Details"));
-          }
-        })
-        .catch((err) => {
-          reject(new Error(err));
-        });
-    }
-  }).catch((err) => {
-    throw new Error(err);
-  });
+  const roleId = adminRole;
+  const userPolicies: ID<IPolicyDoc>[] = otherPolicies ? otherPolicies : [];
+  const deeperRoles = await runAsyncWhileLoop<
+    IDeeperRoles,
+    IGetDeeperRoleHelpers
+  >(
+    '',
+    'main',
+    {
+      roleId,
+      userPolicies,
+    },
+    async (start, helpers) => {
+      const roleDoc = await Roles.findById(helpers.roleId).lean().exec();
+      if (roleDoc) {
+        userType = roleDoc.type;
+        helpers.userPolicies = [
+          ...roleDoc.allowed_policies,
+          ...helpers.userPolicies,
+        ];
+        if (roleDoc.delgates_from) {
+          helpers.roleId = String(roleDoc.delgates_from);
+        }
+        const whileresult: asyncWhileLoopResult<IDeeperRoles> = {
+          nextStartValue: userType,
+          finalResult: {
+            roleDoc,
+            allowedPolicies: helpers.userPolicies,
+          },
+        };
+        return whileresult;
+      } else {
+        userType = 'main';
+        throw new Error("Cannot Find User's Role Details");
+      }
+    },
+  );
   return deeperRoles;
 };
 

--- a/src/plugins/auth/methods/policy/index.ts
+++ b/src/plugins/auth/methods/policy/index.ts
@@ -2,6 +2,8 @@ import { Policies } from '@models';
 import { editDatainDatabase } from '@plugins/auth/helpers';
 import { policy as policyPolicies } from '@plugins/templates/policies';
 
+import { NotAllowed } from '@plugins/errors';
+
 import type { IPolicyDoc, IPolicyModel, IUserDoc } from '@models/types';
 
 /**
@@ -18,13 +20,20 @@ function edit(
   modifiedData: Partial<IPolicyDoc>,
 ): Promise<boolean> {
   const policies = [policyPolicies.edit];
-  return editDatainDatabase<IPolicyDoc, IPolicyModel>(
-    Policies,
-    data,
-    { $set: modifiedData },
-    admin,
-    policies,
-  );
+  const { code, ...otherData } = modifiedData;
+  if (data.code === code || code === undefined) {
+    return editDatainDatabase<IPolicyDoc, IPolicyModel>(
+      Policies,
+      data,
+      { $set: otherData },
+      admin,
+      policies,
+    );
+  } else {
+    throw new NotAllowed(
+      'Not Allowed to edit code property in policy document',
+    );
+  }
 }
 
 export default {

--- a/src/plugins/errors/index.ts
+++ b/src/plugins/errors/index.ts
@@ -6,3 +6,4 @@ export * from './internal-server-error';
 export * from './not-found';
 export * from './un-authorized';
 export * from './too-many-requests';
+export * from './not-allowed';

--- a/src/plugins/errors/not-allowed.ts
+++ b/src/plugins/errors/not-allowed.ts
@@ -1,0 +1,13 @@
+import { BaseError } from '@plugins/errors';
+
+/**
+ * Not Allowed Error Class
+ */
+export class NotAllowed extends BaseError {
+  /**
+   * @param {string} message - Error Message
+   */
+  constructor(message: string) {
+    super(406, 'Not Allowed', message);
+  }
+}

--- a/src/plugins/server/middlewares/cors.ts
+++ b/src/plugins/server/middlewares/cors.ts
@@ -34,7 +34,7 @@ async function corsMiddleware(
           res.setHeader('Access-Control-Allow-Methods', 'GET');
           res.setHeader(
             'Access-Control-Allow-Headers',
-            'x-local-dev-pass,x-secret-pass,X-Requested-With,x-lean-doc-request,content-type, Accept',
+            'x-local-dev-pass, x-secret-pass, X-Requested-With, x-lean-doc-request, x-session-id, x-session-token, content-type, Accept',
           );
           next();
         } else {
@@ -47,7 +47,7 @@ async function corsMiddleware(
               );
               res.setHeader(
                 'Access-Control-Allow-Headers',
-                'x-local-dev-pass,x-secret-pass,X-Requested-With,x-lean-doc-request,content-type, Accept',
+                'x-local-dev-pass, x-secret-pass, X-Requested-With, x-lean-doc-request, x-session-id, x-session-token, content-type, Accept',
               );
               next();
             } else {
@@ -74,7 +74,7 @@ async function corsMiddleware(
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
       res.setHeader(
         'Access-Control-Allow-Headers',
-        'x-local-dev-pass,x-secret-pass,X-Requested-With,x-lean-doc-request,content-type, Accept',
+        'x-secret-pass, X-Requested-With, x-lean-doc-request, x-session-id, x-session-token, content-type, Accept',
       );
       res.setHeader('Access-Control-Allow-Credentials', 'true');
       next();

--- a/src/plugins/server/middlewares/session-checker.ts
+++ b/src/plugins/server/middlewares/session-checker.ts
@@ -1,17 +1,11 @@
 import { Users } from '@models';
 
-import { isUndefined } from '@plugins/misc';
 import { sessionManager } from '@plugins';
 import { errorResponseHandler } from '@plugins/server/responses';
 import { UnAuthorized, BadRequest, InternalServerError } from '@plugins/errors';
 
 // Types
 import type { Request, Response, NextFunction } from 'express';
-
-interface ISessionRequestBody {
-  session_id: string;
-  session_token: string;
-}
 
 /**
  * Checks the Session id and Session Token and Verifies it
@@ -26,8 +20,14 @@ export default async function (
   next: NextFunction,
 ): Promise<void> {
   try {
-    const { session_id, session_token }: ISessionRequestBody = req.body;
-    if (!isUndefined([session_id, session_token])) {
+    const session_id = req.headers['x-session-id'];
+    const session_token = req.headers['x-session-token'];
+    if (
+      session_id &&
+      typeof session_id === 'string' &&
+      session_token &&
+      typeof session_token === 'string'
+    ) {
       const sessionBool = await sessionManager.verifySession(
         session_id,
         session_token,
@@ -46,7 +46,7 @@ export default async function (
         throw new UnAuthorized('Session Token is Not Authorized');
       }
     } else {
-      throw new BadRequest('session_id,session_token', 'Request');
+      throw new BadRequest('x-session-id,x-session-token', 'Request.Headers');
     }
   } catch (e) {
     errorResponseHandler(res, e);

--- a/src/plugins/session-manager/verify-session.ts
+++ b/src/plugins/session-manager/verify-session.ts
@@ -1,6 +1,8 @@
 import { Sessions } from '@models';
 import { verifyJWT } from '@plugins/json-web-token';
 
+import { UnAuthorized } from '@plugins/errors';
+
 interface ISessionCheckResponse {
   exists: boolean;
   userid: string;
@@ -32,14 +34,14 @@ export default async function (
           exists: true,
         };
       } else {
-        throw new Error('Payload is Wrong in the JWT');
+        throw new UnAuthorized('Payload is Wrong in the JWT');
       }
     } else {
-      throw new Error(
+      throw new UnAuthorized(
         'Session Token not Matching with the Saved Token in Database',
       );
     }
   } else {
-    throw new Error('Session Document not Found in the Database');
+    throw new UnAuthorized('Session Document not Found in the Database');
   }
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -4,5 +4,7 @@ declare module 'http' {
     'x-local-dev-pass'?: string;
     'x-persist-state'?: string;
     'x-lean-doc-request'?: string;
+    'x-session-id'?: string;
+    'x-session-token'?: string;
   }
 }


### PR DESCRIPTION
## [0.2.0-59](https://github.com/zyndex-drive/server/compare/v0.2.0-58...v0.2.0-59) (2022-06-23)


### Features 🔥

* **plugins/auth/helpers:** write a asyncwhileloop function for use in auth helper functions ([332518b](https://github.com/zyndex-drive/server/commit/332518b5afcc6a0a2ecd10bdbef1954bd9264624))
* **plugins/errors:** add a new not allowed error response class ([b6f415c](https://github.com/zyndex-drive/server/commit/b6f415cf17a03024c469fcdeeab8ec8d59c2272c))


### Others 🔧

* **types/express:** add express header types for x-session-id and x-session-token ([71c88c0](https://github.com/zyndex-drive/server/commit/71c88c008f15b9aa2eb70e6492181f447be81b49))


### Code Refactoring 🖌

* **plugins/server/middleware:** update session checker function to use the new session headers ([e995941](https://github.com/zyndex-drive/server/commit/e995941e35166606121d967cd01403529d977de2))


### Bug Fixes 🛠

* **plugins/auth/helper:** fix mathjs module import line, add owner to heirarchy ([92f0490](https://github.com/zyndex-drive/server/commit/92f0490968481239b469e863763e5234453f111e))
* **plugins/auth/helpers:** remove existing while loop and use asyncwhileloop function ([ef3c1ad](https://github.com/zyndex-drive/server/commit/ef3c1adef73b06420951cafbfc5608dd5cf48f8f))
* **plugins/auth/policy:** restrict editing 'code' prop in policy document ([386af4c](https://github.com/zyndex-drive/server/commit/386af4c49821cdd608baf26fed632ac4c93339c0))
* **plugins/cors:** allow x-session-id & x-session-token to be allowed in cors requests ([f3b6ee7](https://github.com/zyndex-drive/server/commit/f3b6ee72372ce05138c1c76182eb7f017a2c6608))
* **plugins/session-manager:** use updated error classes for more proper responses to user ([cb5d02f](https://github.com/zyndex-drive/server/commit/cb5d02f5e9934bf1e674c5a77892fad0745494c2))